### PR TITLE
Validate expired promo codes separately

### DIFF
--- a/classes/Kohana/Jam/Validator/Rule/Promocode.php
+++ b/classes/Kohana/Jam/Validator/Rule/Promocode.php
@@ -18,13 +18,16 @@ class Kohana_Jam_Validator_Rule_Promocode extends Jam_Validator_Rule {
 		{
 			$model->errors()->add('promo_code_text', 'invalid');
 		}
+		elseif ($promo_code->is_expired())
+		{
+			$model->errors()->add('promo_code_text', 'expired');
+		}
 	}
 
 	public function valid_promo_code($code)
 	{
 		return Jam::all('promo_code')
 			->where('code', '=', $code)
-			->not_expired()
 			->available()
 			->first();
 	}

--- a/classes/Kohana/Jam/Validator/Rule/Purchase/Promocode.php
+++ b/classes/Kohana/Jam/Validator/Rule/Purchase/Promocode.php
@@ -15,13 +15,17 @@ class Kohana_Jam_Validator_Rule_Purchase_Promocode extends Jam_Validator_Rule {
 	{
 		$promo_code = $this->valid_promo_code($value, $model);
 
-		if ($promo_code)
+		if (! $promo_code)
 		{
-			$promo_code->validate_purchase($model);
+			$model->errors()->add('promo_code_text', 'invalid');
+		}
+		elseif ($promo_code->is_expired())
+		{
+			$model->errors()->add('promo_code_text', 'expired');
 		}
 		else
 		{
-			$model->errors()->add('promo_code_text', 'invalid');
+			$promo_code->validate_purchase($model);
 		}
 	}
 
@@ -29,7 +33,6 @@ class Kohana_Jam_Validator_Rule_Purchase_Promocode extends Jam_Validator_Rule {
 	{
 		return Jam::all('promo_code')
 			->where('code', '=', $code)
-			->not_expired()
 			->available_for_purchase($purchase)
 			->first();
 	}

--- a/classes/Kohana/Model/Promo/Code.php
+++ b/classes/Kohana/Model/Promo/Code.php
@@ -43,4 +43,9 @@ class Kohana_Model_Promo_Code extends Jam_Model {
 	{
 		$this->get_insist('promotion')->validate_purchase($purchase);
 	}
+
+	public function is_expired()
+	{
+		return (bool) $this->expires_at AND strtotime($this->expires_at) < time();
+	}
 }

--- a/tests/tests/Jam/Validator/Rule/Purchase/PromocodeTest.php
+++ b/tests/tests/Jam/Validator/Rule/Purchase/PromocodeTest.php
@@ -46,18 +46,6 @@ class Jam_Validator_Rule_Purchase_PromocodeTest extends Testcase_Promotions {
 
 		$result = $validator_rule->valid_promo_code($promo_code3->get('code'), $purchase);
 		$this->assertEquals($promo_code3, $result, 'Should match because its an allow_multiple=TRUE promocode');
-
-		// Expired
-		$promo_code2->update_fields(array('expires_at' => strtotime('-1 day')));
-
-		$result = $validator_rule->valid_promo_code($promo_code2->get('code'), $purchase);
-		$this->assertNull($result);
-
-		// Expired Allow multiple
-		$promo_code3->update_fields(array('expires_at' => strtotime('-1 month')));
-
-		$result = $validator_rule->valid_promo_code($promo_code3->get('code'), $purchase);
-		$this->assertNull($result);
 	}
 
 	/**
@@ -67,18 +55,23 @@ class Jam_Validator_Rule_Purchase_PromocodeTest extends Testcase_Promotions {
 	{
 		$purchase = Jam::find('purchase', 1);
 		$purchase2 = Jam::find('purchase', 1);
+		$purchase3 = Jam::find('purchase', 1);
 		$promo_code = $this->getMock('Model_Promo_Code', array('validate_purchase'), array('promo_code'));
 		$promo_code
 			->expects($this->once())
 			->method('validate_purchase')
 			->with($this->identicalTo($purchase2));
 
+		$expired_promo_code = Jam::build('promo_code', array(
+			'expires_at' => date('Y-m-d H:i:s', strtotime('-1 month')),
+		));
+
 		$validator_rule = $this->getMock('Jam_Validator_Rule_Purchase_Promocode', array('valid_promo_code'), array(array()));
 		$validator_rule
-			->expects($this->exactly(2))
+			->expects($this->exactly(3))
 			->method('valid_promo_code')
 			->with($this->equalTo('PROMOCODE'), $this->isInstanceOf('Model_Purchase'))
-			->will($this->onConsecutiveCalls(NULL, $promo_code));
+			->will($this->onConsecutiveCalls(NULL, $promo_code, $expired_promo_code));
 
 		$validator_rule->validate($purchase, 'promo_code', 'PROMOCODE');
 		$this->assertFalse($purchase->is_valid());
@@ -89,5 +82,12 @@ class Jam_Validator_Rule_Purchase_PromocodeTest extends Testcase_Promotions {
 
 		$validator_rule->validate($purchase2, 'promo_code', 'PROMOCODE');
 		$this->assertTrue($purchase2->is_valid());
+
+		$validator_rule->validate($purchase3, 'promo_code', 'PROMOCODE');
+		$this->assertFalse($purchase3->is_valid());
+
+		$errors = $purchase3->errors()->as_array();
+		$expected = array('promo_code_text' => array('expired' => array()));
+		$this->assertEquals($expected, $errors);
 	}
 }

--- a/tests/tests/Model/Promo/CodeTest.php
+++ b/tests/tests/Model/Promo/CodeTest.php
@@ -44,4 +44,29 @@ class Model_Promo_CodeTest extends Testcase_Promotions {
 
 		$promo_code->validate_purchase($purchase);
 	}
+
+	public function data_is_expired()
+	{
+		return array(
+			array(NULL, FALSE),
+			array('+5 minutes', FALSE),
+			array('+0 minutes', FALSE),
+			array('-5 minutes', TRUE),
+		);
+	}
+
+	/**
+	 * @dataProvider data_is_expired
+	 * @covers Model_Promo_Code::is_expired
+	 */
+	public function test_is_expired($relative_expires_at, $expected)
+	{
+		$promo_code = Jam::build('promo_code', array(
+			'expires_at' => $relative_expires_at
+				? date('Y-m-d H:i:s', strtotime($relative_expires_at))
+				: NULL,
+		));
+
+		$this->assertSame($expected, $promo_code->is_expired());
+	}
 }


### PR DESCRIPTION
This way these errors could be handled in a different way when handling validation errors and
the customer would receive more information.